### PR TITLE
add composite ssm-put-parameter GitHub action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,62 @@
 # ssm-put-parameter
 Composite GitHub action to put parameters to AWS Parameter Store
+1) Validates input parameters (if each parameter in list of possible values)
+2) Runs `aws ssm put-parameter` command with the parameters
+
+### Parameters
+
+| name | required | possible values | default value |
+|------|----------|-----------------|-----------------|
+| name | true | any | none |
+| value | true | any | none |
+| description | false | any | "" |
+| type | false | ["String", "SecureString", "StringList"] | "String" |
+| overwrite | false | ["overwrite", "no-overwrite"] | "no-overwrite" |
+| tier | false | ["Standard" "Advanced", "Intelligent-Tiering"] | "Standard" |
+ 
+### How to use
+Before running aws cli should be set up. Can be used many times in the same job on 'step' level. 
+
+e.g.:
+```yaml
+jobs:
+  staging_parameters:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      # set up aws cli before running the action
+      - name: setup awscli
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      # run the action first time
+      - name: add_test_string_parameter
+        uses: landtechnologies/ssm-put-parameter@v1
+        with:
+          # input parameters for the first run
+          name: /risk/contrived/test_string_parameter
+          value: test_string_parameter_value
+          description: Test string parameter
+          type: String
+          overwrite: overwrite
+          tier: Standard
+
+      # run the action second time
+      - name: add_test_secret_parameter
+        uses: landtechnologies/ssm-put-parameter@v1
+        with:
+          # input parameters for the second run
+          name: /risk/contrived/test_secret_parameter
+          value: ${{ secrets.RISK_CONTRIVED_SECRET_PARAMETER }}
+          description: Test encoded parameter
+          type: SecureString
+          overwrite: overwrite
+          tier: Standard
+```
+
+

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Composite GitHub action to put parameters to AWS Parameter Store
 ### Parameters
 
 | name | required | possible values | default value |
-|------|----------|-----------------|-----------------|
+|------|----------|-----------------|--------------|
 | name | true | any | none |
 | value | true | any | none |
 | description | false | any | "" |
 | type | false | ["String", "SecureString", "StringList"] | "String" |
-| overwrite | false | ["overwrite", "no-overwrite"] | "no-overwrite" |
+| overwrite | false | ["overwrite", "no-overwrite"] | "overwrite" |
 | tier | false | ["Standard" "Advanced", "Intelligent-Tiering"] | "Standard" |
  
 ### How to use

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jobs:
         uses: landtechnologies/ssm-put-parameter@v1
         with:
           # input parameters for the first run
-          name: /risk/contrived/test_string_parameter
+          name: /test/parameter/string
           value: test_string_parameter_value
           description: Test string parameter
           type: String
@@ -51,8 +51,8 @@ jobs:
         uses: landtechnologies/ssm-put-parameter@v1
         with:
           # input parameters for the second run
-          name: /risk/contrived/test_secret_parameter
-          value: ${{ secrets.RISK_CONTRIVED_SECRET_PARAMETER }}
+          name: /test/parameter/encoded
+          value: ${{ secrets.TEST_SECRET_PARAMETER_VALUE }}
           description: Test encoded parameter
           type: SecureString
           overwrite: overwrite

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ jobs:
       - name: setup awscli
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-1
 
       # run the action first time

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,67 @@
+name: "ssm-put-parameter"
+description: "Puts parameter to AWS Parameter Store using AWS CLI"
+inputs:
+  name:
+    description: "Name of the parameter"
+    required: true
+
+  value:
+    description: "Value of the parameter"
+    required: true
+
+  description:
+    description: "Description of the parameter"
+    required: false
+    default: ""
+
+  type:
+    description: "Type of the parameter: [String | SecureString | StringList]"
+    required: false
+    default: "String"
+
+  overwrite:
+    description: "If needed to overwrite the parameter: ['overwrite' | 'no-overwrite']"
+    required: false
+    default: "no-overwrite"
+
+  tier:
+    description: "Tier of the parameter: "
+    required: false
+    default: "Intelligent-Tiering"
+    
+runs:
+  using: "composite"
+  steps:
+    - name: validate-inputs
+      run: |
+        function validate_parameter() {
+          local parameter_name="$1"
+          local parameter_value="$2"
+          local valid_choices=("$3")
+
+          if [[ ! " ${valid_choices[*]} " =~ " $parameter_value " ]]; then
+            echo "Parameter $parameter_name ['$parameter_value'] is not valid, must be one of (${valid_choices[*]})"
+            exit 1
+          fi
+        }
+        
+        valid_types=(String SecureString StringList)
+        validate_parameter "type" "${{ inputs.type }}" "${valid_types[*]}"
+
+        valid_overwrite=(overwrite no-overwrite)
+        validate_parameter "overwrite" "${{ inputs.overwrite }}" "${valid_overwrite[*]}"
+
+        valid_tiers=(Standard Advanced Intelligent-Tiering)
+        validate_parameter "tier" "${{ inputs.tier }}" "${valid_tiers[*]}"
+      shell: bash
+
+    - name: put-parameter
+      run: |
+        aws ssm put-parameter \
+        --name "${{ inputs.name }}" \
+        --value "${{ inputs.value }}" \
+        --description "${{ inputs.description }}" \
+        --type "${{ inputs.type }}" \
+        --tier "${{ inputs.tier }}" \
+        --${{ inputs.overwrite }}
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
   overwrite:
     description: "If needed to overwrite the parameter: ['overwrite' | 'no-overwrite']"
     required: false
-    default: "no-overwrite"
+    default: "overwrite"
 
   tier:
     description: "Tier of the parameter: "


### PR DESCRIPTION
# What
Composite GitHub action which does next:
1) validates input parameters
2) runs `aws ssm put-parameter` command with the parameters

p.s. more information in README.md

# Why
We want to have reusable GitHub action to put parameters to AWS Parameter Store, and have possibility to reuse the action on "step" level
