### PR TITLE
Safe inputs value

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
       run: |
         aws ssm put-parameter \
         --name "${{ inputs.name }}" \
-        --value "${{ inputs.value }}" \
+        --value '${{ inputs.value }}' \
         --description "${{ inputs.description }}" \
         --type "${{ inputs.type }}" \
         --tier "${{ inputs.tier }}" \

--- a/action.yml
+++ b/action.yml
@@ -58,9 +58,9 @@ runs:
     - name: put-parameter
       run: |
         aws ssm put-parameter \
-        --name "${{ inputs.name }}" \
+        --name '${{ inputs.name }}' \
         --value '${{ inputs.value }}' \
-        --description "${{ inputs.description }}" \
+        --description '${{ inputs.description }}' \
         --type "${{ inputs.type }}" \
         --tier "${{ inputs.tier }}" \
         --${{ inputs.overwrite }}

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,8 @@ runs:
       shell: bash
 
     - name: put-parameter
+      # note the single quoting (of inputs.value) is especially important for
+      # things like private keys, which may contain `\n`.
       run: |
         aws ssm put-parameter \
         --name '${{ inputs.name }}' \


### PR DESCRIPTION
When an input has a `\n`, like in a private key, the double quoting of the value would escape it and break the `aws ssm put-parameter` with a cryptic:
> Unknown options: KEY-----nMIIEvg...
> **Error:** Process completed with exit code 252.

Single quoting the input.value resolves the issue, and while we're at it we should single quote the others for safety.